### PR TITLE
add missing annotation and fixes typo

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -165,7 +165,7 @@ module.exports = class extends BaseGenerator {
             }
         } else if (this.buildTool === 'gradle') {
             if (typeof this.addGradleDependencyManagement === 'function') {
-                this.addGradleDependencyManagement('mavenBOM', 'org.springframework.cloud', 'spring-cloud-stream-dependencies', STREAM_CLOUD_DEPENDENCY_VERSION);
+                this.addGradleDependencyManagement('mavenBom', 'org.springframework.cloud', 'spring-cloud-stream-dependencies', STREAM_CLOUD_DEPENDENCY_VERSION);
                 this.addGradleDependency('compile', 'org.springframework.cloud', 'spring-cloud-stream');
                 this.addGradleDependency('compile', 'org.springframework.cloud', 'spring-cloud-starter-stream-rabbit');
             } else {

--- a/generators/app/templates/src/main/java/package/web/rest/_MessageResource.java
+++ b/generators/app/templates/src/main/java/package/web/rest/_MessageResource.java
@@ -29,7 +29,7 @@ public class <%= rabbitMessageName %>Resource {
     @PostMapping("/messages")
     @Timed
     @ResponseStatus(HttpStatus.OK)
-    public void createMessage(Jhi<%= rabbitMessageName %> jhi<%= rabbitMessageName %>) {
+    public void createMessage(@RequestBody Jhi<%= rabbitMessageName %> jhi<%= rabbitMessageName %>) {
         channel.send(MessageBuilder.withPayload(jhi<%= rabbitMessageName %>).setHeader("title", jhi<%= rabbitMessageName %>.getTitle()).build());
     }
 


### PR DESCRIPTION
without the two fixes i could not get the example running on a newly generated jhipster v4.13.3 app.

without the `@RequestBody`

```
curl -H "Content-Type: application/json" localhost:8081/foo/messages -d '{"title":"bar", "body": "baz"}'
```
would lead to

```
curl -X GET localhost:8081/foo/messages
[ {
  "title" : null,
  "body" : null
} ]
```