### PR TITLE
add rabbitmq cloud config

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -184,6 +184,7 @@ module.exports = class extends BaseGenerator {
         this.template('src/main/java/package/domain/_JhiMessage.java', `${javaDir}domain/Jhi${this.rabbitMessageName}.java`);
         this.template('src/main/java/package/service/stream/_MessageSink.java', `${javaDir}service/stream/${this.rabbitMessageName}Sink.java`);
         this.template('src/main/java/package/web/rest/_MessageResource.java', `${javaDir}web/rest/${this.rabbitMessageName}Resource.java`);
+        this.template('src/main/java/package/config/_CloudMessagingConfiguration.java', `${javaDir}config/CloudMessagingConfiguration.java`);
 
         // application-dev.yml
         const yamlAppDevProperties = { };

--- a/generators/app/templates/src/main/java/package/config/_CloudMessagingConfiguration.java
+++ b/generators/app/templates/src/main/java/package/config/_CloudMessagingConfiguration.java
@@ -1,0 +1,17 @@
+package <%= packageName %>.config;
+
+import io.github.jhipster.config.JHipsterConstants;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.cloud.config.java.AbstractCloudConfig;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+@Configuration
+@Profile(JHipsterConstants.SPRING_PROFILE_CLOUD)
+public class CloudMessagingConfiguration extends AbstractCloudConfig {
+    @Bean
+    public ConnectionFactory rabbitFactory() {
+        return connectionFactory().rabbitConnectionFactory();
+    }
+}


### PR DESCRIPTION
In a microservice using both MongoDB and this generator, RabbitMQ failed to connect without this file.

The main-generator offers sth. similar for MongoDB. https://github.com/jhipster/generator-jhipster/blob/master/generators/server/templates/src/main/java/package/config/_CloudDatabaseConfiguration.java

Same as with the `CloudDatabaseConfiguration` above, this file is not relevant for users not running in `SPRING_PROFILE_CLOUD` (e.g. on cloudfoundry)